### PR TITLE
Toggle the recent searches button

### DIFF
--- a/scripts/gitlab.com-shortcuts.user.js
+++ b/scripts/gitlab.com-shortcuts.user.js
@@ -90,6 +90,13 @@ Mousetrap.bind('shift+e', function () {
 })
 
 /**
+ * @brief Toggle the recent searches dropdown
+ */
+Mousetrap.bind('shift+r', function(){
+  clickElement('.filtered-search-history-dropdown-toggle-button')
+})
+
+/**
  * @brief Edit weight on issues
  */
 Mousetrap.bind('w', function(){


### PR DESCRIPTION
Adds a shortcut for showing/hiding the recent searches on gitlab